### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/manusiaedu/55dc8d85-5977-4894-8173-82109b4909a7/fcd198ce-04cb-49a8-ad9d-2c821599a739/_apis/work/boardbadge/5ac359f3-44be-4c79-80e5-9da02933ffc6)](https://dev.azure.com/manusiaedu/55dc8d85-5977-4894-8173-82109b4909a7/_boards/board/t/fcd198ce-04cb-49a8-ad9d-2c821599a739/Microsoft.RequirementCategory)
 # applications


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/manusiaedu/55dc8d85-5977-4894-8173-82109b4909a7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.